### PR TITLE
fix: "Login with Token" button is overflowed with login container

### DIFF
--- a/src/components/ui/common/Login/index.tsx
+++ b/src/components/ui/common/Login/index.tsx
@@ -105,7 +105,7 @@ const Login: Component<LoginComponent> = ({
     <>
       {!logged() && (
         <>
-          <div class="lg:absolute lg:w-1/3 lg:h-3/4 flex flex-col h-full w-full shadow-none  lg:top-36 lg:left-6 md:sm:bg-base-100 lg:bg-base-300/40 backdrop-blur-xl container rounded-xl shadow-xl">
+          <div class="lg:absolute lg:w-1/3 lg:h-auto flex flex-col h-full w-full shadow-none lg:shadow-xl  lg:top-20 lg:left-6 md:sm:bg-base-100 lg:bg-base-300/40 backdrop-blur-xl container rounded-xl">
             <div class="mx-10 my-10 flex items-center gap-2">
               <div class="w-10">
                 <img src="/favicon.png" />
@@ -158,7 +158,7 @@ const Login: Component<LoginComponent> = ({
                     onInput={(e: any) => setPassword(e.currentTarget.value)}
                   ></input>
                   <input
-                    class="input w-full my-2"
+                    class="input w-full my-2 mb-2"
                     id="mfa"
                     type="text"
                     placeholder="2fa Token (Optional, Not yet implemented)"


### PR DESCRIPTION
This pull request contains a fix that "Login with Token is overflowed with the login container

### Preview
![image](https://user-images.githubusercontent.com/64864880/211121405-ede1169a-16ba-4800-aaee-9de90ef58cf2.png)
